### PR TITLE
Fix a Mixin refmap issue, and a handful of smaller things, bumps version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,10 @@
 plugins {
     id 'fabric-loom' version '1.1-SNAPSHOT'
     id 'maven-publish'
+    id 'io.github.juuxel.loom-quiltflower' version '1.7.2'
 }
 
+archivesBaseName = project.archives_base_name
 version = project.mod_version
 group = project.maven_group
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ yarn_mappings=1.19.4+build.1
 loader_version=0.14.17
 
 # Mod Properties
-mod_version=1.2.1+1.19.4
+mod_version=1.2.2+1.19.4
 maven_group=de.dafuqs
 archives_base_name=additionalentityattributes
 

--- a/src/main/java/de/dafuqs/additionalentityattributes/mixin/common/BlockMixin.java
+++ b/src/main/java/de/dafuqs/additionalentityattributes/mixin/common/BlockMixin.java
@@ -17,17 +17,17 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(value = Block.class)
 public abstract class BlockMixin {
-	
+
 	private PlayerEntity additionalEntityAttributes$breakingPlayer;
-	
-	@ModifyArg(method = "dropExperience", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/ExperienceOrbEntity;spawn(Lnet/minecraft/server/world/ServerWorld;Lnet/minecraft/util/math/Vec3d;I)V"), index = 2)
+
+	@ModifyArg(method = "dropExperience", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/ExperienceOrbEntity;spawn(Lnet/minecraft/server/world/ServerWorld;Lnet/minecraft/util/math/Vec3d;I)V"))
 	private int additionalEntityAttributes$modifyExperience(int originalXP) {
 		return (int) (originalXP * Support.getExperienceMod(additionalEntityAttributes$breakingPlayer));
 	}
-	
+
 	@Inject(method = "afterBreak", at = @At("HEAD"))
 	public void additionalEntityAttributes$saveBreakingPlayer(World world, PlayerEntity player, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity, ItemStack stack, CallbackInfo callbackInfo) {
 		additionalEntityAttributes$breakingPlayer = player;
 	}
-	
+
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "additionalentityattributes",
   "version": "${version}",
-  "name": "Additionalentityattributes",
+  "name": "Additional Entity Attributes",
   "description": "Additional Entity Attributes",
   "authors": [
     "DaFuqs",


### PR DESCRIPTION
- The auto-generated refmap in the mixins.json for this project is based on folder name, unless specified in the build.gradle. Since the default folder when cloning is "AdditionalEntityAttributes", any jars built would look for a non-existing refmap
- Changes the name of the mod from "Additionalentityattributes" in the FMJ to "Additional Entity Attributes"
- Adds quiltflower as a gradle plugin, which allows for faster and more accurate decompilations
- Removes an unnecessary index from the BlockMixin modifyExperience signature  