### PR TITLE
Move magic damage reduction after resistance

### DIFF
--- a/src/main/java/de/dafuqs/additionalentityattributes/mixin/common/LivingEntityMixin.java
+++ b/src/main/java/de/dafuqs/additionalentityattributes/mixin/common/LivingEntityMixin.java
@@ -103,7 +103,7 @@ public abstract class LivingEntityMixin {
         }
     }
 
-    @ModifyVariable(method = "applyArmorToDamage", at = @At("HEAD"), argsOnly = true)
+    @ModifyVariable(method = "modifyAppliedDamage", at = @At(value = "LOAD", ordinal = 4), argsOnly = true)
     private float additionalEntityAttributes$reduceMagicDamage(float damage, DamageSource source) {
         EntityAttributeInstance magicProt = ((LivingEntity) (Object) this).getAttributeInstance(AdditionalEntityAttributes.MAGIC_PROTECTION);
 


### PR DESCRIPTION
Moves the injection point of Magic Protection at the start of the enchantment handling. This means that Magic Protection will reduce damage after resistance and absorption, in contrast to before where it would decrease the damage before applying any modifiers. 
This is effectively a small buff to the damage reduction, at the cost of eating your absorption too. 