### PR TITLE
Update to 1.20.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     // fapi unfreezes the attributes registry while mods are initializing
     modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-    include(implementation(annotationProcessor("com.github.llamalad7.mixinextras:mixinextras-fabric:0.2.0-beta.6")))
+    include(implementation(annotationProcessor("com.github.llamalad7.mixinextras:mixinextras-fabric:0.2.0-rc.5")))
 }
 
 loom {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,15 +2,15 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.20
-yarn_mappings=1.20+build.1
-loader_version=0.14.21
+minecraft_version=1.20.2
+yarn_mappings=1.20.2+build.1
+loader_version=0.14.22
 
 # Mod Properties
-mod_version=1.4.0+1.20.0
+mod_version=1.5.0+1.20.2
 maven_group=de.dafuqs
 archives_base_name=additionalentityattributes
 
 # Dependencies
 # check this on https://modmuss50.me/fabric.html
-fabric_version=0.83.0+1.20
+fabric_version=0.89.2+1.20.2

--- a/src/main/java/de/dafuqs/additionalentityattributes/mixin/common/ApplyBonusLootFunctionMixin.java
+++ b/src/main/java/de/dafuqs/additionalentityattributes/mixin/common/ApplyBonusLootFunctionMixin.java
@@ -10,6 +10,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.loot.context.LootContext;
 import net.minecraft.loot.context.LootContextParameters;
 import net.minecraft.loot.function.ApplyBonusLootFunction;
+import net.minecraft.registry.entry.RegistryEntry;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -18,14 +19,15 @@ import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
 @Mixin(ApplyBonusLootFunction.class)
 public abstract class ApplyBonusLootFunctionMixin {
-	
+
 	@Shadow
 	@Final
-	Enchantment enchantment;
+	private ApplyBonusLootFunction.Formula formula;
+
 	@Shadow
 	@Final
-	ApplyBonusLootFunction.Formula formula;
-	
+	private RegistryEntry<Enchantment> enchantment;
+
 	@ModifyVariable(method = "process(Lnet/minecraft/item/ItemStack;Lnet/minecraft/loot/context/LootContext;)Lnet/minecraft/item/ItemStack;", at = @At("STORE"), ordinal = 1)
 	public int additionalEntityAttributes$applyBonusLoot(int oldValue, ItemStack stack, LootContext context) {
 		// if the player has the ANOTHER_DRAW effect the bonus loot of
@@ -33,7 +35,7 @@ public abstract class ApplyBonusLootFunctionMixin {
 		ItemStack itemStack = context.get(LootContextParameters.TOOL);
 		Entity entity = context.get(LootContextParameters.THIS_ENTITY);
 		if (itemStack != null && entity instanceof LivingEntity livingEntity) {
-			int enchantmentLevel = EnchantmentHelper.getLevel(this.enchantment, itemStack);
+			int enchantmentLevel = EnchantmentHelper.getLevel(this.enchantment.value(), itemStack);
 			if (enchantmentLevel > 0) {
 				EntityAttributeInstance attributeInstance = livingEntity.getAttributeInstance(AdditionalEntityAttributes.BONUS_LOOT_COUNT_ROLLS);
 				if (attributeInstance != null) {

--- a/src/main/java/de/dafuqs/additionalentityattributes/mixin/common/RandomChanceLootConditionMixin.java
+++ b/src/main/java/de/dafuqs/additionalentityattributes/mixin/common/RandomChanceLootConditionMixin.java
@@ -15,11 +15,11 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(RandomChanceLootCondition.class)
 public abstract class RandomChanceLootConditionMixin {
-	
+
 	@Shadow
 	@Final
-	float chance;
-	
+	private float chance;
+
 	@Inject(at = @At("RETURN"), method = "test(Lnet/minecraft/loot/context/LootContext;)Z", cancellable = true)
 	public void additionalEntityAttributes$applyBonusLoot(LootContext lootContext, CallbackInfoReturnable<Boolean> cir) {
 		// if the result was to not drop a drop before reroll

--- a/src/main/java/de/dafuqs/additionalentityattributes/mixin/common/RandomChanceWithLootingLootConditionMixin.java
+++ b/src/main/java/de/dafuqs/additionalentityattributes/mixin/common/RandomChanceWithLootingLootConditionMixin.java
@@ -18,7 +18,7 @@ public abstract class RandomChanceWithLootingLootConditionMixin {
 	
 	@Shadow
 	@Final
-	float chance;
+	private float chance;
 	
 	@Inject(at = @At("RETURN"), method = "test(Lnet/minecraft/loot/context/LootContext;)Z", cancellable = true)
 	public void additionalEntityAttributes$applyBonusLoot(LootContext lootContext, CallbackInfoReturnable<Boolean> cir) {


### PR DESCRIPTION
Also bumps the version of MixinExtras to `0.2.0-rc.5`, as it's causing issues to mods that are using the release candidate versions of MixinExtras