### PR TITLE
Add Jump Height attribute.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ These attributes allow mod compatibility and serve as an API for mods that make 
 - LUNG_CAPACITY: Extra air when underwater / suffocating
 - BONUS_LOOT_COUNT_ROLLS: Controls the number of drops the player receives when using enchantments such as Loot and Luck.
 - BONUS_RARE_LOOT_ROLLS: The number of times the chance-based loot table is rolled.
+- JUMP_HEIGHT: Controls the jump height of the player.
 - DROPPED_EXPERIENCE: Changes the amount of experience dropped from mining blocks and killing mobs.
 - MAGIC_PROTECTION: Reduces the amount of magic damage taken.
 

--- a/src/main/java/de/dafuqs/additionalentityattributes/AdditionalEntityAttributes.java
+++ b/src/main/java/de/dafuqs/additionalentityattributes/AdditionalEntityAttributes.java
@@ -76,6 +76,12 @@ public class AdditionalEntityAttributes implements ModInitializer {
 	 *
 	 */
 	public static final EntityAttribute BONUS_RARE_LOOT_ROLLS = createAttribute("generic.bonus_rare_loot_rolls", 0.0D, 0.0D, 128.0);
+
+	/**
+	 * Controls the jump height of the player.
+	 * By default, the player jumps at a height of 0.42.
+	 */
+	public static final EntityAttribute JUMP_HEIGHT = createAttribute("generic.jump_height", 0.0D, -1024.0, 1024.0);
 	
 	/**
 	 * Modifies the experience dropped from mining blocks and killing mobs.
@@ -100,6 +106,7 @@ public class AdditionalEntityAttributes implements ModInitializer {
         register("dig_speed", DIG_SPEED);
 		register("bonus_rare_loot_rolls", BONUS_RARE_LOOT_ROLLS);
 		register("bonus_loot_count_rolls", BONUS_LOOT_COUNT_ROLLS);
+		register("jump_height", JUMP_HEIGHT);
         register("dropped_experience", DROPPED_EXPERIENCE);
         register("magic_protection", MAGIC_PROTECTION);
 	}

--- a/src/main/java/de/dafuqs/additionalentityattributes/mixin/common/LivingEntityMixin.java
+++ b/src/main/java/de/dafuqs/additionalentityattributes/mixin/common/LivingEntityMixin.java
@@ -1,5 +1,6 @@
 package de.dafuqs.additionalentityattributes.mixin.common;
 
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import de.dafuqs.additionalentityattributes.*;
 import net.fabricmc.api.*;
 import net.minecraft.entity.*;
@@ -31,6 +32,7 @@ public abstract class LivingEntityMixin {
         info.getReturnValue().add(AdditionalEntityAttributes.DIG_SPEED);
         info.getReturnValue().add(AdditionalEntityAttributes.BONUS_LOOT_COUNT_ROLLS);
         info.getReturnValue().add(AdditionalEntityAttributes.BONUS_RARE_LOOT_ROLLS);
+        info.getReturnValue().add(AdditionalEntityAttributes.JUMP_HEIGHT);
         info.getReturnValue().add(AdditionalEntityAttributes.MAGIC_PROTECTION);
     }
 
@@ -112,5 +114,31 @@ public abstract class LivingEntityMixin {
             damage = (float) Math.max(damage - magicProt.getValue(), 0);
         }
         return damage;
+    }
+
+    @ModifyReturnValue(method = "getJumpVelocity", at = @At("RETURN"))
+    public float additionalEntityAttributes$modifyJumpVelocity(float original) {
+        EntityAttributeInstance instance = ((LivingEntity) (Object) this).getAttributeInstance(AdditionalEntityAttributes.JUMP_HEIGHT);
+
+        if (instance != null) {
+            float totalAmount = original;
+            for (EntityAttributeModifier modifier : instance.getModifiers()) {
+                float amount = (float) modifier.getValue();
+
+                if (modifier.getOperation() == EntityAttributeModifier.Operation.ADDITION)
+                    totalAmount += amount;
+                else
+                    totalAmount *= (amount + 1);
+            }
+
+            // Players will run this method twice, so we have to do
+            // some math to make sure that it's accurate.
+            if ((LivingEntity)(Object)this instanceof PlayerEntity) {
+                totalAmount = original + (totalAmount - original) / 2;
+            }
+            original = totalAmount;
+        }
+
+        return original;
     }
 }

--- a/src/main/resources/assets/additionalentityattributes/lang/en_us.json
+++ b/src/main/resources/assets/additionalentityattributes/lang/en_us.json
@@ -8,6 +8,7 @@
   "attribute.name.generic.additionalentityattributes.generic.dig_speed": "Dig Speed",
   "attribute.name.generic.additionalentityattributes.generic.bonus_rare_loot_rolls": "Additional Rare Loot Rolls",
   "attribute.name.generic.additionalentityattributes.generic.bonus_loot_count_rolls": "Additional Enchantment Loot Rolls",
+  "attribute.name.generic.additionalentityattributes.generic.jump_height": "Jump Height",
   "attribute.name.generic.additionalentityattributes.player.dropped_experience": "Dropped Experience",
   "attribute.name.generic.additionalentityattributes.player.magic_protection": "Magic Protection"
 }


### PR DESCRIPTION
Adds a jump height attribute.

This hooks into `getJumpVelocity` in LivingEntity.
There is extra logic for players to get the same results as non players as players' jump method runs on both the client and the server, which screws with the logic.