### PR TITLE
1.21.4 Water and Lava movement fixes

### DIFF
--- a/common/src/main/java/de/dafuqs/additionalentityattributes/mixin/common/LivingEntityMixin.java
+++ b/common/src/main/java/de/dafuqs/additionalentityattributes/mixin/common/LivingEntityMixin.java
@@ -1,43 +1,15 @@
 package de.dafuqs.additionalentityattributes.mixin.common;
 
-import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import de.dafuqs.additionalentityattributes.*;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.AttributeInstance;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
 @Mixin(LivingEntity.class)
 public abstract class LivingEntityMixin {
-
-    @ModifyArg(method = "travel", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/LivingEntity;moveRelative(FLnet/minecraft/world/phys/Vec3;)V", ordinal = 0))
-    public float additionalEntityAttributes$waterSpeed(float original) {
-        AttributeInstance waterSpeed = ((LivingEntity) (Object) this).getAttribute(AdditionalEntityAttributes.WATER_SPEED);
-        if (waterSpeed == null) {
-            return original;
-        } else {
-            if (waterSpeed.getBaseValue() != original) {
-                waterSpeed.setBaseValue(original);
-            }
-            return (float) waterSpeed.getValue();
-        }
-    }
-
-    @ModifyExpressionValue(method = "travel", at = {@At(value = "CONSTANT", args = "doubleValue=0.5D", ordinal = 0), @At(value = "CONSTANT", args = "doubleValue=0.5D", ordinal = 1), @At(value = "CONSTANT", args = "doubleValue=0.5D", ordinal = 2)})
-    private double additionalEntityAttributes$increasedLavaSpeed(double original) {
-        AttributeInstance lavaSpeed = ((LivingEntity) (Object) this).getAttribute(AdditionalEntityAttributes.LAVA_SPEED);
-        if (lavaSpeed == null) {
-            return original;
-        } else {
-            if (lavaSpeed.getBaseValue() != original) {
-                lavaSpeed.setBaseValue(original);
-            }
-            return lavaSpeed.getValue();
-        }
-    }
 
     @ModifyVariable(method = "getDamageAfterMagicAbsorb", at = @At(value = "LOAD", ordinal = 4), argsOnly = true)
     private float additionalEntityAttributes$reduceMagicDamage(float damage, DamageSource source) {

--- a/fabric/src/main/java/de/dafuqs/additionalentityattributes/mixin/fabric/LivingEntityMixin.java
+++ b/fabric/src/main/java/de/dafuqs/additionalentityattributes/mixin/fabric/LivingEntityMixin.java
@@ -62,4 +62,31 @@ public abstract class LivingEntityMixin {
             return -waterSpeed.getValue();
         }
     }
+
+    @ModifyArg(method = "travelInFluid", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/LivingEntity;moveRelative(FLnet/minecraft/world/phys/Vec3;)V", ordinal = 0))
+    public float additionalEntityAttributes$waterSpeed(float original) {
+        AttributeInstance waterSpeed = ((LivingEntity) (Object) this).getAttribute(AdditionalEntityAttributes.WATER_SPEED);
+        if (waterSpeed == null) {
+            return original;
+        } else {
+            if (waterSpeed.getBaseValue() != original) {
+                waterSpeed.setBaseValue(original);
+            }
+            return (float) waterSpeed.getValue();
+        }
+    }
+
+    @ModifyArg(method = "travelInFluid", at = @At(target = "Lnet/minecraft/world/phys/Vec3;scale(D)Lnet/minecraft/world/phys/Vec3;", value = "INVOKE", ordinal = 0))
+    private double additionalEntityAttributes$increasedLavaSpeed(double original) {
+        AttributeInstance lavaSpeed = ((LivingEntity) (Object) this).getAttribute(AdditionalEntityAttributes.LAVA_SPEED);
+        if (lavaSpeed == null) {
+            return original;
+        } else {
+            if (lavaSpeed.getBaseValue() != original) {
+                lavaSpeed.setBaseValue(original);
+            }
+            return lavaSpeed.getValue();
+        }
+    }
+
 }

--- a/neoforge/src/main/java/de/dafuqs/additionalentityattributes/mixin/neoforge/LivingEntityMixin.java
+++ b/neoforge/src/main/java/de/dafuqs/additionalentityattributes/mixin/neoforge/LivingEntityMixin.java
@@ -1,0 +1,37 @@
+package de.dafuqs.additionalentityattributes.mixin.neoforge;
+
+import de.dafuqs.additionalentityattributes.AdditionalEntityAttributes;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.attributes.AttributeInstance;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+@Mixin(LivingEntity.class)
+public abstract class LivingEntityMixin {
+    @ModifyArg(method = "travelInFluid(Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/level/material/FluidState;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/LivingEntity;moveRelative(FLnet/minecraft/world/phys/Vec3;)V", ordinal = 0))
+    public float additionalEntityAttributes$waterSpeed(float original) {
+        AttributeInstance waterSpeed = ((LivingEntity) (Object) this).getAttribute(AdditionalEntityAttributes.WATER_SPEED);
+        if (waterSpeed == null) {
+            return original;
+        } else {
+            if (waterSpeed.getBaseValue() != original) {
+                waterSpeed.setBaseValue(original);
+            }
+            return (float) waterSpeed.getValue();
+        }
+    }
+
+    @ModifyArg(method = "travelInFluid(Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/level/material/FluidState;)V", at = @At(target = "Lnet/minecraft/world/phys/Vec3;scale(D)Lnet/minecraft/world/phys/Vec3;", value = "INVOKE", ordinal = 0))
+    private double additionalEntityAttributes$increasedLavaSpeed(double original) {
+        AttributeInstance lavaSpeed = ((LivingEntity) (Object) this).getAttribute(AdditionalEntityAttributes.LAVA_SPEED);
+        if (lavaSpeed == null) {
+            return original;
+        } else {
+            if (lavaSpeed.getBaseValue() != original) {
+                lavaSpeed.setBaseValue(original);
+            }
+            return lavaSpeed.getValue();
+        }
+    }
+}

--- a/neoforge/src/main/resources/additionalentityattributes.neoforge.mixins.json
+++ b/neoforge/src/main/resources/additionalentityattributes.neoforge.mixins.json
@@ -4,7 +4,8 @@
   "package": "de.dafuqs.additionalentityattributes.mixin.neoforge",
   "compatibilityLevel": "JAVA_21",
   "mixins": [
-    "ILivingEntityExtensionMixin"
+    "ILivingEntityExtensionMixin",
+    "LivingEntityMixin"
   ],
   "client": [
   ],


### PR DESCRIPTION
Split off a NeoForge-specific LivingEntityMixin to deal with neo patches to travelInFluid. Change $increasedLvaSpeed to @ModifyArg on Vec3.scale()