### PR TITLE
Update to 26.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
 plugins {
-    id("fabric-loom") version "1.14-SNAPSHOT" apply false
-    id("net.neoforged.moddev") version "2.0.123" apply false
+    id("net.fabricmc.fabric-loom") version "1.15-SNAPSHOT" apply false
+    id("net.neoforged.moddev") version "2.0.141" apply false
 }

--- a/buildSrc/src/main/groovy/additionalentityattributes-common.gradle
+++ b/buildSrc/src/main/groovy/additionalentityattributes-common.gradle
@@ -8,7 +8,7 @@ base {
 }
 
 java {
-    toolchain.languageVersion = JavaLanguageVersion.of(21)
+    toolchain.languageVersion = JavaLanguageVersion.of(25)
     withSourcesJar()
     withJavadocJar()
 }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -10,10 +10,6 @@ neoForge {
     if (at.exists()) {
         setAccessTransformers(at)
     }
-    parchment {
-        minecraftVersion = project.parchment_minecraft
-        mappingsVersion = project.parchment_version
-    }
 }
 
 dependencies {

--- a/common/src/main/java/de/dafuqs/additionalentityattributes/mixin/client/CameraMixin.java
+++ b/common/src/main/java/de/dafuqs/additionalentityattributes/mixin/client/CameraMixin.java
@@ -1,13 +1,14 @@
 package de.dafuqs.additionalentityattributes.mixin.client;
 
 import de.dafuqs.additionalentityattributes.Support;
-import net.minecraft.client.Camera;
-import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.LivingEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+import net.minecraft.client.Camera;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
 
 // We run at a lower priority because we clamp values.
 // This is so Pehkui and other mods that may touch this may run without limits.
@@ -16,7 +17,7 @@ public class CameraMixin {
     
     @Shadow private Entity entity;
     
-    @ModifyVariable(method = "setup", at = @At("STORE"), ordinal = 1)
+    @ModifyVariable(method = "alignWithEntity", at = @At("STORE"), name = "cameraScale")
     private float additionalEntityAttributes$updateCameraScaleValue(float scale) {
         if (this.entity instanceof LivingEntity living) {
             return (float) Support.getModelHeight(living, scale);

--- a/common/src/main/java/de/dafuqs/additionalentityattributes/mixin/client/EndermanRendererMixin.java
+++ b/common/src/main/java/de/dafuqs/additionalentityattributes/mixin/client/EndermanRendererMixin.java
@@ -1,17 +1,18 @@
 package de.dafuqs.additionalentityattributes.mixin.client;
 
 import de.dafuqs.additionalentityattributes.ClientSupport;
-import net.minecraft.client.renderer.entity.EndermanRenderer;
-import net.minecraft.client.renderer.entity.state.EndermanRenderState;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+import net.minecraft.client.renderer.entity.EndermanRenderer;
+import net.minecraft.client.renderer.entity.state.EndermanRenderState;
 
 // We run at a lower priority because we clamp values.
 // This is so Pehkui and other mods that may touch this may run without limits.
 @Mixin(value = EndermanRenderer.class, priority = 500)
 public class EndermanRendererMixin {
-    @ModifyVariable(method = "getRenderOffset(Lnet/minecraft/client/renderer/entity/state/EndermanRenderState;)Lnet/minecraft/world/phys/Vec3;", at = @At("LOAD"))
+    @ModifyVariable(method = "getRenderOffset(Lnet/minecraft/client/renderer/entity/state/EndermanRenderState;)Lnet/minecraft/world/phys/Vec3;", at = @At("LOAD"), name = "d")
     private double additionalEntityAttributes$applyModelScaleToEndermanOffset(double d, EndermanRenderState renderState) {
         return ClientSupport.getModelWidth(renderState, d / 0.02) * 0.02;
     }

--- a/common/src/main/java/de/dafuqs/additionalentityattributes/mixin/client/LivingEntityRendererMixin.java
+++ b/common/src/main/java/de/dafuqs/additionalentityattributes/mixin/client/LivingEntityRendererMixin.java
@@ -6,10 +6,6 @@ import de.dafuqs.additionalentityattributes.AdditionalEntityAttributes;
 import de.dafuqs.additionalentityattributes.ClientSupport;
 import de.dafuqs.additionalentityattributes.CustomValueRenderState;
 import de.dafuqs.additionalentityattributes.Support;
-import net.minecraft.client.model.EntityModel;
-import net.minecraft.client.renderer.entity.LivingEntityRenderer;
-import net.minecraft.client.renderer.entity.state.LivingEntityRenderState;
-import net.minecraft.world.entity.LivingEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -17,11 +13,16 @@ import org.spongepowered.asm.mixin.injection.ModifyArgs;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
 
+import net.minecraft.client.model.EntityModel;
+import net.minecraft.client.renderer.entity.LivingEntityRenderer;
+import net.minecraft.client.renderer.entity.state.LivingEntityRenderState;
+import net.minecraft.world.entity.LivingEntity;
+
 // We run at a lower priority because we clamp values.
 // This is so Pehkui and other mods that may touch this may run without limits.
 @Mixin(value = LivingEntityRenderer.class, priority = 500)
 public abstract class LivingEntityRendererMixin<T extends LivingEntity, S extends LivingEntityRenderState, M extends EntityModel<? super S>> {
-    @ModifyArgs(method = "submit(Lnet/minecraft/client/renderer/entity/state/LivingEntityRenderState;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;Lnet/minecraft/client/renderer/state/CameraRenderState;)V", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/vertex/PoseStack;scale(FFF)V", ordinal = 0))
+    @ModifyArgs(method = "submit(Lnet/minecraft/client/renderer/entity/state/LivingEntityRenderState;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;Lnet/minecraft/client/renderer/state/level/CameraRenderState;)V", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/vertex/PoseStack;scale(FFF)V", ordinal = 0))
     private void additionalEntityAttributes$applyModelScales(Args args, @Local(argsOnly = true) LivingEntityRenderState renderState) {
         float x = args.get(0);
         float y = args.get(1);

--- a/common/src/main/java/de/dafuqs/additionalentityattributes/mixin/common/ApplyBonusCountMixin.java
+++ b/common/src/main/java/de/dafuqs/additionalentityattributes/mixin/common/ApplyBonusCountMixin.java
@@ -1,21 +1,23 @@
 package de.dafuqs.additionalentityattributes.mixin.common;
 
 import de.dafuqs.additionalentityattributes.AdditionalEntityAttributes;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
 import net.minecraft.core.Holder;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.AttributeInstance;
+import net.minecraft.world.item.ItemInstance;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.level.storage.loot.LootContext;
 import net.minecraft.world.level.storage.loot.functions.ApplyBonusCount;
 import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
-import org.spongepowered.asm.mixin.Final;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
 @Mixin(ApplyBonusCount.class)
 public abstract class ApplyBonusCountMixin {
@@ -28,11 +30,11 @@ public abstract class ApplyBonusCountMixin {
 	@Final
 	private Holder<Enchantment> enchantment;
 
-	@ModifyVariable(method = "run", at = @At("STORE"), ordinal = 1)
+	@ModifyVariable(method = "run", at = @At("STORE"), name = "newCount")
 	public int additionalEntityAttributes$applyBonusLoot(int original, ItemStack stack, LootContext context) {
 		// the bonus loot of this method gets rerolled x times
 		// and the highest result will be returned
-		ItemStack itemStack = context.getOptionalParameter(LootContextParams.TOOL);
+		ItemInstance itemStack = context.getOptionalParameter(LootContextParams.TOOL);
 		Entity entity = context.getOptionalParameter(LootContextParams.THIS_ENTITY);
 		if (itemStack != null && entity instanceof LivingEntity livingEntity) {
 			int enchantmentLevel = EnchantmentHelper.getItemEnchantmentLevel(this.enchantment, itemStack);

--- a/common/src/main/java/de/dafuqs/additionalentityattributes/mixin/common/PlayerMixin.java
+++ b/common/src/main/java/de/dafuqs/additionalentityattributes/mixin/common/PlayerMixin.java
@@ -1,19 +1,20 @@
 package de.dafuqs.additionalentityattributes.mixin.common;
 
+import java.util.List;
+
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import de.dafuqs.additionalentityattributes.AdditionalEntityAttributes;
 import de.dafuqs.additionalentityattributes.AdditionalEntityAttributesEntityTags;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.AttributeInstance;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.phys.AABB;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.ModifyVariable;
-
-import java.util.List;
 
 @Mixin(Player.class)
 public abstract class PlayerMixin {
@@ -33,7 +34,7 @@ public abstract class PlayerMixin {
 	
 	// since we filter on an entity tag here, we cannot simply expand the original box
 	// and therefore have to run a second `getOtherEntities` check :(
-	@ModifyVariable(method = "aiStep", at = @At("STORE"))
+	@ModifyVariable(method = "aiStep", at = @At("STORE"), name = "entities")
 	private List<Entity> additionalEntityAttributes$adjustCollectionRange(List<Entity> original) {
         Player thisPlayer = (Player)(Object) this;
 		AttributeInstance instance = thisPlayer.getAttribute(AdditionalEntityAttributes.COLLECTION_RANGE);
@@ -48,7 +49,7 @@ public abstract class PlayerMixin {
 			
 			original.addAll(thisPlayer.level().getEntities(thisPlayer, expandedBox, entity -> {
 				EntityType<?> type = entity.getType();
-				return type.is(AdditionalEntityAttributesEntityTags.AFFECTED_BY_COLLECTION_RANGE) && !original.contains(entity);
+				return type.builtInRegistryHolder().is(AdditionalEntityAttributesEntityTags.AFFECTED_BY_COLLECTION_RANGE) && !original.contains(entity);
 			}));
 		}
 		return original;

--- a/common/src/main/resources/additionalentityattributes.mixins.json
+++ b/common/src/main/resources/additionalentityattributes.mixins.json
@@ -3,7 +3,7 @@
     "minVersion": "0.8",
     "package": "de.dafuqs.additionalentityattributes.mixin",
     "refmap": "additionalentityattributes.refmap.json",
-    "compatibilityLevel": "JAVA_21",
+    "compatibilityLevel": "JAVA_25",
     "mixins": [
         "common.ApplyBonusCountMixin",
         "common.BlockMixin",

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -1,17 +1,12 @@
-import org.apache.tools.ant.filters.LineContains
-
 plugins {
     id 'additionalentityattributes-loader'
-    id 'fabric-loom'
+    id 'net.fabricmc.fabric-loom'
 }
 dependencies {
     minecraft "com.mojang:minecraft:${minecraft_version}"
-    mappings loom.layered {
-        officialMojangMappings()
-        parchment("org.parchmentmc.data:parchment-${parchment_minecraft}:${parchment_version}@zip")
-    }
-    modImplementation("net.fabricmc:fabric-loader:${fabric_loader_version}")
-    modImplementation("net.fabricmc.fabric-api:fabric-api:${fabric_api_version}")
+
+    implementation("net.fabricmc:fabric-loader:${fabric_loader_version}")
+    implementation("net.fabricmc.fabric-api:fabric-api:${fabric_api_version}")
 }
 
 loom {

--- a/fabric/src/main/resources/additionalentityattributes.accesswidener
+++ b/fabric/src/main/resources/additionalentityattributes.accesswidener
@@ -1,3 +1,3 @@
-accessWidener v2 named
+accessWidener v2 official
 
 accessible class net/minecraft/world/level/storage/loot/functions/ApplyBonusCount$Formula

--- a/fabric/src/main/resources/additionalentityattributes.fabric.mixins.json
+++ b/fabric/src/main/resources/additionalentityattributes.fabric.mixins.json
@@ -3,7 +3,7 @@
   "minVersion": "0.8",
   "package": "de.dafuqs.additionalentityattributes.mixin.fabric",
   "refmap": "additionalentityattributes.refmap.json",
-  "compatibilityLevel": "JAVA_21",
+  "compatibilityLevel": "JAVA_25",
   "mixins": [
     "LivingEntityMixin",
     "PlayerMixin"

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,29 +2,26 @@
 # Every field you add must be added to the root build.gradle expandProps map.
 
 # Mod Properties
-version=2.2.3+1.21.11
+version=2.2.3+26.1
 maven_group=de.dafuqs
 mod_id=additionalentityattributes
 
 # Common
-minecraft_version=1.21.11
+minecraft_version=26.1
 # https://github.com/neoforged/NeoForm
 # https://maven.neoforged.net/releases/net/neoforged/neoform/
-neoform_version=1.21.11-20251209.172050
-# The version of ParchmentMC that is used, see https://parchmentmc.org/docs/getting-started#choose-a-version for new versions
-parchment_minecraft=1.21.10
-parchment_version=2025.10.12
+neoform_version=26.1-1
 
 # Fabric
-fabric_api_version=0.139.5+1.21.11
-fabric_loader_version=0.18.2
-fabric_minecraft_version_range=>=1.21.10
+fabric_api_version=0.144.3+26.1
+fabric_loader_version=0.18.4
+fabric_minecraft_version_range=>=26.1
 
 # NeoForge
 # https://neoforged.net/
-neoforge_version=21.11.6-beta
-neoforge_version_range=[21.11.6-beta,]
-neoforge_minecraft_version_range=[1.21.11,)
+neoforge_version=26.1.0.12-beta
+neoforge_version_range=[26.1.0.12-beta,]
+neoforge_minecraft_version_range=[26.1,)
 neoforge_loader_version_range=[4,)
 
 # Gradle

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -12,10 +12,6 @@ neoForge {
     if (at.exists()) {
         setAccessTransformers(at)
     }
-    parchment {
-        minecraftVersion = parchment_minecraft
-        mappingsVersion = parchment_version
-    }
     runs {
         configureEach {
             systemProperty('neoforge.enabledGameTestNamespaces', mod_id)

--- a/neoforge/src/main/resources/additionalentityattributes.neoforge.mixins.json
+++ b/neoforge/src/main/resources/additionalentityattributes.neoforge.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "de.dafuqs.additionalentityattributes.mixin.neoforge",
-  "compatibilityLevel": "JAVA_21",
+  "compatibilityLevel": "JAVA_25",
   "mixins": [
     "ILivingEntityExtensionMixin",
     "LivingEntityMixin"


### PR DESCRIPTION
howdy, it's me again
additional stuff:
- removed Parchment mappings, not needed anymore
- switched `@ModifyVariable` calls to use names directly now to make it more obvious, especially since we're no longer obfuscated

also, can't PR this rn, heading to sleep, but I think 1.21.11 has a bug where the camera scale mixin is targetting cameraDistance instead, probably needs a different ordinal.