### PR TITLE
Fix breakingPlayer weak reference nullability crash (closes #62)

### DIFF
--- a/common/src/main/java/de/dafuqs/additionalentityattributes/mixin/common/BlockMixin.java
+++ b/common/src/main/java/de/dafuqs/additionalentityattributes/mixin/common/BlockMixin.java
@@ -1,13 +1,8 @@
 package de.dafuqs.additionalentityattributes.mixin.common;
 
+import java.lang.ref.WeakReference;
+
 import de.dafuqs.additionalentityattributes.Support;
-import net.minecraft.core.BlockPos;
-import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
@@ -16,7 +11,13 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.lang.ref.*;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
 
 @Mixin(Block.class)
 public abstract class BlockMixin {
@@ -31,7 +32,7 @@ public abstract class BlockMixin {
 	
 	@ModifyArg(method = "popExperience", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/ExperienceOrb;award(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/phys/Vec3;I)V"))
 	private int additionalEntityAttributes$modifyExperience(int originalXP) {
-		if(additionalEntityAttributes$breakingPlayer.get() != null) {
+		if(additionalEntityAttributes$breakingPlayer != null && additionalEntityAttributes$breakingPlayer.get() != null) {
 			return (int) (originalXP * Support.getExperienceMod(additionalEntityAttributes$breakingPlayer.get()));
 		}
 		return originalXP;


### PR DESCRIPTION
This needs to be cherry picked to the 1.21.8 and 26.1 branches too, I can handle that if needed. I've been seeing this crash a lot in issue reports, I only just got to be able to fix it.